### PR TITLE
Reverse load order of Javascript files

### DIFF
--- a/view/layout/admin.phtml
+++ b/view/layout/admin.phtml
@@ -11,9 +11,9 @@
     <?php echo $this->headLink()->prependStylesheet('//netdna.bootstrapcdn.com/twitter-bootstrap/2.1.1/css/bootstrap-combined.min.css') ?>
 
     <!-- Scripts -->
-    <?php echo $this->headScript()->prependFile('//html5shiv.googlecode.com/svn/trunk/html5.js', 'text/javascript', array('conditional' => 'lt IE 9',))
+    <?php echo $this->headScript()->prependFile('//netdna.bootstrapcdn.com/twitter-bootstrap/2.1.1/js/bootstrap.min.js')
                                   ->prependFile('//code.jquery.com/jquery.min.js')
-                                  ->prependFile('//netdna.bootstrapcdn.com/twitter-bootstrap/2.1.1/js/bootstrap.min.js') ?>
+                                  ->prependFile('//html5shiv.googlecode.com/svn/trunk/html5.js', 'text/javascript', array('conditional' => 'lt IE 9',)) ?>
 
   </head>
 


### PR DESCRIPTION
jQuery library must be loaded before Twitter Bootstrap JS
(See: https://github.com/twitter/bootstrap/issues/4773)
