### PR TITLE
fix broken link to ZfcRbac in README file

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # ZfcAdmin Module for Zend Framework 2
-Version 0.1.0 created by [Jurian Sluiman](http://juriansluiman.nl/en) and [Martin Shwalbe](https://github.com/Hounddog).
+Version 0.2.1 created by [Jurian Sluiman](http://juriansluiman.nl) and [Martin Shwalbe](https://github.com/Hounddog).
 
 ## Introduction
 ZfcAdmin is a minimal admin interface for generic administrative purposes. It is a common screen with navigation that hides behind authentication and authorization.

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ ZfcAdmin is enabled to be installed via composer. Load `zf-commons/zfc-admin` in
 If you do not want to use composer, clone this project (either as a git submodule or not) into `./vendor/` directory.
 
 ## Usage
-ZfcAdmin allows you to create routes under a single parent "admin" route. You can also use it to enable navigation in your admin layout. Furthermore integration of [BjyAuthorize](https://github.com/bjyoungblood/BjyAuthorize) and [ZfcRbac](https://github.com/spiffyjr/ZfcRbac) is provided.
+ZfcAdmin allows you to create routes under a single parent "admin" route. You can also use it to enable navigation in your admin layout. Furthermore integration of [BjyAuthorize](https://github.com/bjyoungblood/BjyAuthorize) and [ZfcRbac](https://github.com/ZF-Commons/zfc-rbac) is provided.
 
 The complete configuration is flexible, so you can update the zfcadmin parent route, its children, the navigation and all default provided view scripts. Read more in the [documentation](docs/1.Introduction.md) about usage and customization of ZfcAdmin.
 


### PR DESCRIPTION
Apparently, the ZfcRbac repo has been moved
